### PR TITLE
Cleaning up the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The official [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) se
     </a>
 </div>
 
-
 <br /><br />
 > [!IMPORTANT]
 > This SDK is not yet ready for production use. To complete setup please follow the steps outlined in your [workspace](https://app.speakeasy.com/org/launchdarkly/mcp). Delete this section before > publishing to a package manager.
@@ -163,64 +162,9 @@ npx -y --package @launchdarkly/mcp-server -- mcp start --help
 For supported JavaScript runtimes, please consult [RUNTIMES.md](RUNTIMES.md).
 <!-- End Requirements [requirements] -->
 
-<!-- Start SDK Example Usage [usage] -->
-## SDK Example Usage
+<!-- No SDK Example Usage [usage] -->
 
-### Example
-
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-<!-- End SDK Example Usage [usage] -->
-
-<!-- Start Authentication [security] -->
-## Authentication
-
-### Per-Client Security Schemes
-
-This SDK supports the following security scheme globally:
-
-| Name     | Type   | Scheme  | Environment Variable   |
-| -------- | ------ | ------- | ---------------------- |
-| `apiKey` | apiKey | API key | `LAUNCHDARKLY_API_KEY` |
-
-To authenticate with the API the `apiKey` parameter must be set when initializing the SDK client instance. For example:
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-<!-- End Authentication [security] -->
+<!-- No Authentication [security] -->
 
 <!-- Start Available Resources and Operations [operations] -->
 ## Available Resources and Operations
@@ -252,338 +196,29 @@ run();
 </details>
 <!-- End Available Resources and Operations [operations] -->
 
-<!-- Start Standalone functions [standalone-funcs] -->
-## Standalone functions
+<!-- No Standalone functions [standalone-funcs] -->
 
-All the methods listed above are available as standalone functions. These
-functions are ideal for use in applications running in the browser, serverless
-runtimes or other environments where application bundle size is a primary
-concern. When using a bundler to build your application, all unused
-functionality will be either excluded from the final bundle or tree-shaken away.
+<!-- No Retries [retries] -->
 
-To read more about standalone functions, check [FUNCTIONS.md](./FUNCTIONS.md).
+<!-- No Error Handling [errors] -->
 
-<details>
+<!-- No Server Selection [server] -->
 
-<summary>Available standalone functions</summary>
+<!-- No Custom HTTP Client [http-client] -->
 
-- [`aiConfigsCreate`](docs/sdks/aiconfigs/README.md#create) - Create new AI Config
-- [`aiConfigsCreateVariation`](docs/sdks/aiconfigs/README.md#createvariation) - Create AI Config variation
-- [`aiConfigsDelete`](docs/sdks/aiconfigs/README.md#delete) - Delete AI Config
-- [`aiConfigsDeleteVariation`](docs/sdks/aiconfigs/README.md#deletevariation) - Delete AI Config variation
-- [`aiConfigsGet`](docs/sdks/aiconfigs/README.md#get) - Get AI Config
-- [`aiConfigsGetVariation`](docs/sdks/aiconfigs/README.md#getvariation) - Get AI Config variation
-- [`aiConfigsList`](docs/sdks/aiconfigs/README.md#list) - List AI Configs
-- [`aiConfigsUpdate`](docs/sdks/aiconfigs/README.md#update) - Update AI Config
-- [`aiConfigsUpdateVariation`](docs/sdks/aiconfigs/README.md#updatevariation) - Update AI Config variation
-- [`featureFlagsCreate`](docs/sdks/featureflags/README.md#create) - Create a feature flag
-- [`featureFlagsDelete`](docs/sdks/featureflags/README.md#delete) - Delete feature flag
-- [`featureFlagsGet`](docs/sdks/featureflags/README.md#get) - Get feature flag
-- [`featureFlagsList`](docs/sdks/featureflags/README.md#list) - List feature flags
-- [`featureFlagsPatch`](docs/sdks/featureflags/README.md#patch) - Update feature flag
-
-</details>
-<!-- End Standalone functions [standalone-funcs] -->
-
-<!-- Start Retries [retries] -->
-## Retries
-
-Some of the endpoints in this SDK support retries.  If you use the SDK without any configuration, it will fall back to the default retry strategy provided by the API.  However, the default retry strategy can be overridden on a per-operation basis, or across the entire SDK.
-
-To change the default retry strategy for a single API call, simply provide a retryConfig object to the call:
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  }, {
-    retries: {
-      strategy: "backoff",
-      backoff: {
-        initialInterval: 1,
-        maxInterval: 50,
-        exponent: 1.1,
-        maxElapsedTime: 100,
-      },
-      retryConnectionErrors: false,
-    },
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-
-If you'd like to override the default retry strategy for all operations that support retries, you can provide a retryConfig at SDK initialization:
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  retryConfig: {
-    strategy: "backoff",
-    backoff: {
-      initialInterval: 1,
-      maxInterval: 50,
-      exponent: 1.1,
-      maxElapsedTime: 100,
-    },
-    retryConnectionErrors: false,
-  },
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-<!-- End Retries [retries] -->
-
-<!-- Start Error Handling [errors] -->
-## Error Handling
-
-Some methods specify known errors which can be thrown. All the known errors are enumerated in the `models/errors/errors.ts` module. The known errors for a method are documented under the *Errors* tables in SDK docs. For example, the `list` method may throw the following errors:
-
-| Error Type                    | Status Code | Content Type     |
-| ----------------------------- | ----------- | ---------------- |
-| errors.InvalidRequestErrorRep | 400         | application/json |
-| errors.UnauthorizedErrorRep   | 401         | application/json |
-| errors.ForbiddenErrorRep      | 403         | application/json |
-| errors.NotFoundErrorRep       | 404         | application/json |
-| errors.RateLimitedErrorRep    | 429         | application/json |
-| errors.APIError               | 4XX, 5XX    | \*/\*            |
-
-If the method throws an error and it is not captured by the known errors, it will default to throwing a `APIError`.
-
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-import {
-  ForbiddenErrorRep,
-  InvalidRequestErrorRep,
-  NotFoundErrorRep,
-  RateLimitedErrorRep,
-  SDKValidationError,
-  UnauthorizedErrorRep,
-} from "@launchdarkly/mcp-server/models/errors";
-
-const launchDarkly = new LaunchDarkly({
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  let result;
-  try {
-    result = await launchDarkly.featureFlags.list({
-      projectKey: "<value>",
-    });
-
-    // Handle the result
-    console.log(result);
-  } catch (err) {
-    switch (true) {
-      // The server response does not match the expected SDK schema
-      case (err instanceof SDKValidationError): {
-        // Pretty-print will provide a human-readable multi-line error message
-        console.error(err.pretty());
-        // Raw value may also be inspected
-        console.error(err.rawValue);
-        return;
-      }
-      case (err instanceof InvalidRequestErrorRep): {
-        // Handle err.data$: InvalidRequestErrorRepData
-        console.error(err);
-        return;
-      }
-      case (err instanceof UnauthorizedErrorRep): {
-        // Handle err.data$: UnauthorizedErrorRepData
-        console.error(err);
-        return;
-      }
-      case (err instanceof ForbiddenErrorRep): {
-        // Handle err.data$: ForbiddenErrorRepData
-        console.error(err);
-        return;
-      }
-      case (err instanceof NotFoundErrorRep): {
-        // Handle err.data$: NotFoundErrorRepData
-        console.error(err);
-        return;
-      }
-      case (err instanceof RateLimitedErrorRep): {
-        // Handle err.data$: RateLimitedErrorRepData
-        console.error(err);
-        return;
-      }
-      default: {
-        // Other errors such as network errors, see HTTPClientErrors for more details
-        throw err;
-      }
-    }
-  }
-}
-
-run();
-
-```
-
-Validation errors can also occur when either method arguments or data returned from the server do not match the expected format. The `SDKValidationError` that is thrown as a result will capture the raw value that failed validation in an attribute called `rawValue`. Additionally, a `pretty()` method is available on this error that can be used to log a nicely formatted multi-line string since validation errors can list many issues and the plain error string may be difficult read when debugging.
-
-In some rare cases, the SDK can fail to get a response from the server or even make the request due to unexpected circumstances such as network conditions. These types of errors are captured in the `models/errors/httpclienterrors.ts` module:
-
-| HTTP Client Error                                    | Description                                          |
-| ---------------------------------------------------- | ---------------------------------------------------- |
-| RequestAbortedError                                  | HTTP request was aborted by the client               |
-| RequestTimeoutError                                  | HTTP request timed out due to an AbortSignal signal  |
-| ConnectionError                                      | HTTP client was unable to make a request to a server |
-| InvalidRequestError                                  | Any input used to create a request is invalid        |
-| UnexpectedClientError                                | Unrecognised or unexpected error                     |
-<!-- End Error Handling [errors] -->
-
-<!-- Start Server Selection [server] -->
-## Server Selection
-
-### Select Server by Index
-
-You can override the default server globally by passing a server index to the `serverIdx: number` optional parameter when initializing the SDK client instance. The selected server will then be used as the default on the operations that use it. This table lists the indexes associated with the available servers:
-
-| #   | Server                         | Description     |
-| --- | ------------------------------ | --------------- |
-| 0   | `https://app.launchdarkly.com` |  Default        |
-| 1   | `https://app.launchdarkly.us`  |  Federal        |
-| 2   | `https://app.launchdarkly.com` | Prod API server |
-
-#### Example
-
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  serverIdx: 2,
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-
-### Override Server URL Per-Client
-
-The default server can also be overridden globally by passing a URL to the `serverURL: string` optional parameter when initializing the SDK client instance. For example:
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const launchDarkly = new LaunchDarkly({
-  serverURL: "https://app.launchdarkly.com",
-  apiKey: process.env["LAUNCHDARKLY_API_KEY"] ?? "",
-});
-
-async function run() {
-  const result = await launchDarkly.featureFlags.list({
-    projectKey: "<value>",
-  });
-
-  // Handle the result
-  console.log(result);
-}
-
-run();
-
-```
-<!-- End Server Selection [server] -->
-
-<!-- Start Custom HTTP Client [http-client] -->
-## Custom HTTP Client
-
-The TypeScript SDK makes API calls using an `HTTPClient` that wraps the native
-[Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). This
-client is a thin wrapper around `fetch` and provides the ability to attach hooks
-around the request lifecycle that can be used to modify the request or handle
-errors and response.
-
-The `HTTPClient` constructor takes an optional `fetcher` argument that can be
-used to integrate a third-party HTTP client or when writing tests to mock out
-the HTTP client and feed in fixtures.
-
-The following example shows how to use the `"beforeRequest"` hook to to add a
-custom header and a timeout to requests and how to use the `"requestError"` hook
-to log errors:
-
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-import { HTTPClient } from "@launchdarkly/mcp-server/lib/http";
-
-const httpClient = new HTTPClient({
-  // fetcher takes a function that has the same signature as native `fetch`.
-  fetcher: (request) => {
-    return fetch(request);
-  }
-});
-
-httpClient.addHook("beforeRequest", (request) => {
-  const nextRequest = new Request(request, {
-    signal: request.signal || AbortSignal.timeout(5000)
-  });
-
-  nextRequest.headers.set("x-custom-header", "custom value");
-
-  return nextRequest;
-});
-
-httpClient.addHook("requestError", (error, request) => {
-  console.group("Request Error");
-  console.log("Reason:", `${error}`);
-  console.log("Endpoint:", `${request.method} ${request.url}`);
-  console.groupEnd();
-});
-
-const sdk = new LaunchDarkly({ httpClient });
-```
-<!-- End Custom HTTP Client [http-client] -->
-
-<!-- Start Debugging [debug] -->
-## Debugging
-
-You can setup your SDK to emit debug logs for SDK requests and responses.
-
-You can pass a logger that matches `console`'s interface as an SDK option.
-
-> [!WARNING]
-> Beware that debug logging will reveal secrets, like API tokens in headers, in log messages printed to a console or files. It's recommended to use this feature only during local development and not in production.
-
-```typescript
-import { LaunchDarkly } from "@launchdarkly/mcp-server";
-
-const sdk = new LaunchDarkly({ debugLogger: console });
-```
-
-You can also enable a default debug logger by setting an environment variable `LAUNCHDARKLY_DEBUG` to true.
-<!-- End Debugging [debug] -->
+<!-- No Debugging [debug] -->
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->
+
+## Available environments
+
+Most customer accounts run on LaunchDarkly's commercial (default) environment. Customers on other environments can specify the `--server-url` argument to connect to the appropriate environment. For example, customers on LaunchDarkly's Federal environment should specify `--server-url https://app.launchdarkly.us` when starting their MCP server.
+
+| #   | Server URL                        | Environment          |
+| --- | --------------------------------- | -------------------- |
+| 0   | `https://app.launchdarkly.com`    | Commercial (Default) |
+| 1   | `https://app.launchdarkly.us`     | Federal              |
+| 2   | `https://app.eu.launchdarkly.com` | EU                   |
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ The official [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) se
     </a>
 </div>
 
-<br /><br />
-> [!IMPORTANT]
-> This SDK is not yet ready for production use. To complete setup please follow the steps outlined in your [workspace](https://app.speakeasy.com/org/launchdarkly/mcp). Delete this section before > publishing to a package manager.
-
 <!-- No Summary [summary] -->
 
 <!-- Start Table of Contents [toc] -->
@@ -36,74 +32,12 @@ The official [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) se
 
 <!-- End Table of Contents [toc] -->
 
-<!-- Start SDK Installation [installation] -->
-## SDK Installation
+<!-- No SDK Installation [installation] -->
+## Installation
 
-The SDK can be installed with either [npm](https://www.npmjs.com/), [pnpm](https://pnpm.io/), [bun](https://bun.sh/) or [yarn](https://classic.yarnpkg.com/en/) package managers.
+This MCP server can be installed in any AI client that supports the MCP protocol. Refer to your AI client's instructions if it isn't listed here.
 
-### NPM
-
-```bash
-npm add @launchdarkly/mcp-server
-```
-
-### PNPM
-
-```bash
-pnpm add @launchdarkly/mcp-server
-```
-
-### Bun
-
-```bash
-bun add @launchdarkly/mcp-server
-```
-
-### Yarn
-
-```bash
-yarn add @launchdarkly/mcp-server zod
-
-# Note that Yarn does not install peer dependencies automatically. You will need
-# to install zod as shown above.
-```
-
-> [!NOTE]
-> This package is published with CommonJS and ES Modules (ESM) support.
-
-
-### Model Context Protocol (MCP) Server
-
-This SDK is also an installable MCP server where the various SDK methods are
-exposed as tools that can be invoked by AI applications.
-
-> Node.js v20 or greater is required to run the MCP server from npm.
-
-<details>
-<summary>Claude installation steps</summary>
-
-Add the following server definition to your `claude_desktop_config.json` file:
-
-```json
-{
-  "mcpServers": {
-    "LaunchDarkly": {
-      "command": "npx",
-      "args": [
-        "-y", "--package", "@launchdarkly/mcp-server",
-        "--",
-        "mcp", "start",
-        "--api-key", "..."
-      ]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Cursor installation steps</summary>
+### Cursor installation steps
 
 Create a `.cursor/mcp.json` file in your project root with the following content:
 
@@ -114,47 +48,46 @@ Create a `.cursor/mcp.json` file in your project root with the following content
       "command": "npx",
       "args": [
         "-y", "--package", "@launchdarkly/mcp-server",
-        "--",
-        "mcp", "start",
-        "--api-key", "..."
+        "--", "mcp", "start",
+        "--api-key", "api-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       ]
     }
   }
 }
 ```
 
-</details>
+Specify your API key as found on LaunchDarkly's Authorization page.
 
-You can also run MCP servers as a standalone binary with no additional dependencies. You must pull these binaries from available Github releases:
+### Claude installation steps
 
-```bash
-curl -L -o mcp-server \
-    https://github.com/{org}/{repo}/releases/download/{tag}/mcp-server-bun-darwin-arm64 && \
-chmod +x mcp-server
-```
-
-If the repo is a private repo you must add your Github PAT to download a release `-H "Authorization: Bearer {GITHUB_PAT}"`.
-
+Add the following server definition to your `claude_desktop_config.json` file:
 
 ```json
 {
   "mcpServers": {
-    "Todos": {
-      "command": "./DOWNLOAD/PATH/mcp-server",
+    "LaunchDarkly": {
+      "command": "npx",
       "args": [
-        "start"
+        "-y", "--package", "@launchdarkly/mcp-server",
+        "--", "mcp", "start",
+        "--api-key", "api-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       ]
     }
   }
 }
 ```
 
-For a full list of server arguments, run:
+Specify your API key as found on LaunchDarkly's Authorization page.
 
-```sh
-npx -y --package @launchdarkly/mcp-server -- mcp start --help
+### Standalone binary installation steps
+
+You can also run the MCP server as a standalone binary with no additional dependencies. You must pull these binaries from available Github releases while specifying the appropriate `tag` value:
+
+```bash
+curl -L -o mcp-server \
+    https://github.com/launchdarkly/mcp-server/releases/download/{tag}/mcp-server-bun-darwin-arm64 && \
+chmod +x mcp-server
 ```
-<!-- End SDK Installation [installation] -->
 
 <!-- Start Requirements [requirements] -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Specify your API key as found on LaunchDarkly's Authorization page.
 
 ### Standalone binary installation steps
 
-You can also run the MCP server as a standalone binary with no additional dependencies. You must pull these binaries from available Github releases while specifying the appropriate `tag` value:
+You can also run the MCP server as a standalone binary with no additional dependencies. You must pull these binaries from available GitHub releases while specifying the appropriate `tag` value:
 
 ```bash
 curl -L -o mcp-server \


### PR DESCRIPTION
I'm removing a lot of boilerplate documentation that was focused on programmatic usage.