### PR TITLE
Adding the license and keywords again

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -24,7 +24,14 @@ typescript:
     dependencies: {}
     devDependencies: {}
     peerDependencies: {}
-  additionalPackageJSON: {}
+  additionalPackageJSON:
+    license: MIT
+    keywords:
+      - feature-flags
+      - feature-toggles
+      - launchdarkly
+      - mcp
+      - modelcontextprotocol
   author: LaunchDarkly
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIError


### PR DESCRIPTION
One more time -- because the Speakeasy auto generation process overwrote my package.json content changes. This will persist those changes.