### PR TITLE
Minor capitalization consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For supported JavaScript runtimes, please consult [RUNTIMES.md](RUNTIMES.md).
 
 <!-- Placeholder for Future Speakeasy SDK Sections -->
 
-## Available environments
+## Available Environments
 
 Most customer accounts run on LaunchDarkly's commercial (default) environment. Customers on other environments can specify the `--server-url` argument to connect to the appropriate environment. For example, customers on LaunchDarkly's Federal environment should specify the `--server-url https://app.launchdarkly.us` argument when starting their MCP server.
 


### PR DESCRIPTION
Minor - I noticed that this is the only header that's sentence case instead of title case. This change aligns the style of our manually-added headers with the auto-generated ones.