### PR TITLE
adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is this a support request?**
+This issue tracker is maintained by LaunchDarkly developers and is intended for feedback on the MCP server code. If you're not sure whether the problem you are having is specifically related to the MCP server, or to the LaunchDarkly service overall, it may be more appropriate to contact the LaunchDarkly support team; they can help to investigate the problem and will consult the engineering team if necessary. You can submit a support request by going [here](https://support.launchdarkly.com/hc/en-us/requests/new) or by emailing support@launchdarkly.com.
+
+Note that issues filed on this issue tracker are publicly accessible. Do not provide any private account information on your issues. If your problem is specific to your account, you should submit a support request as described above.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add any log output related to your problem.
+
+**Package version**
+The version of the MCP server that you are using.
+
+**Language version, developer tools**
+For instance, Node 23.11.0 or Cursor 0.50.7.
+
+**OS/platform**
+For instance, Ubuntu 16.04, Windows 10, or macOS 15.4.1.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support request
+    url: https://support.launchdarkly.com/hc/en-us/requests/new
+    about: File your support requests with LaunchDarkly's support team

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I would love to see the MCP server [...does something new...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+**Related issues**
+
+Provide links to any issues in this repository or elsewhere relating to this pull request.
+
+**Describe the solution you've provided**
+
+Provide a clear and concise description of what you expect to happen.
+
+**Describe alternatives you've considered**
+
+Provide a clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context about the pull request here.


### PR DESCRIPTION
Now that we're going to get more public traffic, let's configure our issue templates to match what we have in our open-source SDK repositories.