### PR TITLE
Add GitHub Actions workflow to publish to MCP registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -16,26 +16,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npm run test --if-present
-
-      - name: Build package
-        run: npm run build
-
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher


### PR DESCRIPTION
## Related issues

This PR addresses the request to publish the LaunchDarkly MCP server to the Model Context Protocol registry following the guidelines at https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md.

## Describe the solution you've provided

This PR adds a new GitHub Actions workflow (`.github/workflows/publish-mcp-registry.yml`) that publishes the MCP server to the MCP registry. The workflow:

- Triggers on GitHub releases (when published) or manual dispatch via `workflow_dispatch`
- Uses GitHub OIDC authentication to login to the MCP registry
- Downloads and uses the official MCP Publisher tool to submit the package
- Focuses exclusively on MCP registry publishing (does not duplicate npm publishing)

The workflow coordinates with the existing Speakeasy publishing process by handling only MCP registry submission while leaving npm publishing to the existing `sdk_publish.yaml` workflow.

## Describe alternatives you've considered

**Alternative trigger strategies:**
- **Triggering after Speakeasy workflow completion**: Considered but rejected because the Speakeasy workflow doesn't create GitHub releases, making coordination difficult
- **Triggering on every npm publish**: Would require complex coordination and could lead to unwanted MCP registry submissions

**Alternative authentication methods:**
- **API tokens**: GitHub OIDC is preferred by the MCP registry guidelines for better security

**Integration approaches:**
- **Modifying existing Speakeasy workflow**: Considered but would complicate the generated workflow and could interfere with Speakeasy's automation
- **Single unified workflow**: Would duplicate npm publishing logic already handled by Speakeasy

## Additional context

**Important review points:**
- ⚠️ **External dependency**: The workflow downloads MCP Publisher from `github.com/modelcontextprotocol/registry/releases/download/v1.0.0/` - verify this URL and version are stable
- ⚠️ **OIDC configuration**: Requires repository to be configured for GitHub OIDC authentication with MCP registry
- ⚠️ **Untested workflow**: This is a new workflow that hasn't been tested in practice
- ⚠️ **MCP registry compatibility**: Assumes current repository structure meets MCP registry requirements

**Workflow coordination:**
- Existing `sdk_publish.yaml` (Speakeasy) handles npm publishing when `.speakeasy/gen.lock` changes
- This workflow handles MCP registry publishing when GitHub releases are created
- No npm publishing duplication (removed after reviewer feedback)

**Testing strategy:**
- Workflow can be tested manually using `workflow_dispatch` trigger
- Recommend testing on a fork or with a dry-run approach first

---

**Link to Devin run:** https://app.devin.ai/sessions/0e8e01387d7e447ea3d82a638f30cc8f  
**Requested by:** @kparkinson-ld (Kane Parkinson)