### PR TITLE
Adding installation instructions for env var usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,29 @@ Then, configure your server definition to reference your local clone. For exampl
 }
 ```
 
+### Installation steps using environment variables
+
+Some AI clients allow for accessing environment variables within MCP configurations. In AI clients where this is supported, you can configure your MCP server to read from an environment variable like `MCP_LD_TOKEN` as follows:
+
+```json
+{
+  "mcpServers": {
+    "launchdarkly": {
+      "command": "npx",
+      "args": [
+        "-y", "--package", "@launchdarkly/mcp-server", "--", "mcp", "start",
+        "--api-key", "$LD_ACCESS_TOKEN"
+      ],
+      "env": {
+        "LD_ACCESS_TOKEN": "MCP_LD_TOKEN"
+      }
+    }
+  }
+}
+```
+
+This won't work in AI clients (such as Cursor) which don't support accessing environment variables directly within MCP configurations. As a workaround, you can invoke a local script from your MCP configuration. See [here](https://github.com/launchdarkly/mcp-server/issues/26#issuecomment-3064419507) for an example.
+
 <!-- Start Requirements [requirements] -->
 ## Requirements
 


### PR DESCRIPTION
This content update is extracted out from a recent exploration of Zach's when he was authenticating the MCP server with an environment variable.