### PR TITLE
[REL-10407] [Flag status tools] Updating OAS to consider FlagStatuses.LastRequested as nullable. 

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: cc3a5766-8b39-40da-a0be-fff57173d8e1
 management:
-  docChecksum: 0372014a029d3ca9b9ac775262de6c3c
+  docChecksum: 75d07115da631245e6b9951136727d0f
   docVersion: "2.0"
   speakeasyVersion: 1.580.0
   generationVersion: 2.654.2
-  releaseVersion: 0.4.1
-  configChecksum: ba03e6d279042b1bd9d661581831a3a7
+  releaseVersion: 0.4.2
+  configChecksum: 024bcd611bb1b466d728403f71b3b046
   repoURL: https://github.com/launchdarkly/mcp-server.git
   installationURL: https://github.com/launchdarkly/mcp-server
   published: true
@@ -28,6 +28,7 @@ features:
     ignores: 2.81.1
     mcpServer: 0.9.3
     nameOverrides: 2.81.2
+    nullables: 0.1.1
     responseFormat: 0.2.3
     retries: 2.83.0
     sdkHooks: 0.3.0

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -24,7 +24,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.4.1
+  version: 0.4.2
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.580.0
 sources:
     LaunchDarkly REST API:
         sourceNamespace: launchdarkly-rest-api
-        sourceRevisionDigest: sha256:95f3d4d718e88f72b27db5a22f2f827b642bc3283965fe76f83771570b5d8496
-        sourceBlobDigest: sha256:1b7ce6418864f3e86e17377a10e6060d1ea5cbbcf7f4cd1cfa0876c3439fb602
+        sourceRevisionDigest: sha256:1868673c9276536f547b28da2d496ef29e98642910836bdb4aac97a8a7407bb8
+        sourceBlobDigest: sha256:629c41ee8c6344e7a1122e74c9fd56d8cdf0581428e1baf659cb3812c1ac871a
         tags:
             - latest
             - "2.0"
@@ -11,10 +11,10 @@ targets:
     launchdarkly-mcp-server:
         source: LaunchDarkly REST API
         sourceNamespace: launchdarkly-rest-api
-        sourceRevisionDigest: sha256:95f3d4d718e88f72b27db5a22f2f827b642bc3283965fe76f83771570b5d8496
-        sourceBlobDigest: sha256:1b7ce6418864f3e86e17377a10e6060d1ea5cbbcf7f4cd1cfa0876c3439fb602
+        sourceRevisionDigest: sha256:1868673c9276536f547b28da2d496ef29e98642910836bdb4aac97a8a7407bb8
+        sourceBlobDigest: sha256:629c41ee8c6344e7a1122e74c9fd56d8cdf0581428e1baf659cb3812c1ac871a
         codeSamplesNamespace: launchdarkly-rest-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:cbb7edd595888f46d13195a79ca2698a5cab5bbb30a27054db9c290c40638dda
+        codeSamplesRevisionDigest: sha256:bb64ea7b196a1e4d87408c6a5b64b013ad437af9d8b015036abf4567b74f6492
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.580.0

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@launchdarkly/mcp-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "bin": {
         "mcp": "bin/mcp-server.js"

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@launchdarkly/mcp-server",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "bin": {
         "mcp": "bin/mcp-server.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "LaunchDarkly",
   "keywords": [
     "feature-flags",

--- a/schemas/openapi.json
+++ b/schemas/openapi.json
@@ -37544,6 +37544,7 @@
           "lastRequested": {
             "type": "string",
             "format": "date-time",
+            "nullable": true,
             "description": "Timestamp of last time flag was requested",
             "example": "2020-02-05T18:17:01.514Z"
           },
@@ -38512,6 +38513,7 @@
           "lastRequested": {
             "type": "string",
             "format": "date-time",
+            "nullable": true,
             "description": "Timestamp of last time flag was requested",
             "example": "2020-02-05T18:17:01.514Z"
           },

--- a/schemas/output.json
+++ b/schemas/output.json
@@ -38478,6 +38478,7 @@
           "lastRequested": {
             "type": "string",
             "format": "date-time",
+            "nullable": true,
             "description": "Timestamp of last time flag was requested",
             "example": "2020-02-05T18:17:01.514Z"
           },
@@ -39446,6 +39447,7 @@
           "lastRequested": {
             "type": "string",
             "format": "date-time",
+            "nullable": true,
             "description": "Timestamp of last time flag was requested",
             "example": "2020-02-05T18:17:01.514Z"
           },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,8 +69,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "2.0",
-  sdkVersion: "0.4.1",
+  sdkVersion: "0.4.2",
   genVersion: "2.654.2",
   userAgent:
-    "speakeasy-sdk/typescript 0.4.1 2.654.2 2.0 @launchdarkly/mcp-server",
+    "speakeasy-sdk/typescript 0.4.2 2.654.2 2.0 @launchdarkly/mcp-server",
 } as const;

--- a/src/mcp-server/mcp-server.ts
+++ b/src/mcp-server/mcp-server.ts
@@ -19,7 +19,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
   name: "mcp",
   versionInfo: {
-    currentVersion: "0.4.1",
+    currentVersion: "0.4.2",
   },
 });
 

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -43,7 +43,7 @@ export function createMCPServer(deps: {
 }) {
   const server = new McpServer({
     name: "LaunchDarkly",
-    version: "0.4.1",
+    version: "0.4.2",
   });
 
   const client = new LaunchDarklyCore({

--- a/src/models/components/featureflagstatus.ts
+++ b/src/models/components/featureflagstatus.ts
@@ -30,7 +30,7 @@ export type FeatureFlagStatus = {
   /**
    * Timestamp of last time flag was requested
    */
-  lastRequested?: Date | undefined;
+  lastRequested?: Date | null | undefined;
   /**
    * Default value seen from code
    */
@@ -64,8 +64,8 @@ export const FeatureFlagStatus$inboundSchema: z.ZodType<
   unknown
 > = z.object({
   name: Name$inboundSchema,
-  lastRequested: z.string().datetime({ offset: true }).transform(v =>
-    new Date(v)
+  lastRequested: z.nullable(
+    z.string().datetime({ offset: true }).transform(v => new Date(v)),
   ).optional(),
   default: z.any().optional(),
 });
@@ -73,7 +73,7 @@ export const FeatureFlagStatus$inboundSchema: z.ZodType<
 /** @internal */
 export type FeatureFlagStatus$Outbound = {
   name: string;
-  lastRequested?: string | undefined;
+  lastRequested?: string | null | undefined;
   default?: any | undefined;
 };
 
@@ -84,7 +84,8 @@ export const FeatureFlagStatus$outboundSchema: z.ZodType<
   FeatureFlagStatus
 > = z.object({
   name: Name$outboundSchema,
-  lastRequested: z.date().transform(v => v.toISOString()).optional(),
+  lastRequested: z.nullable(z.date().transform(v => v.toISOString()))
+    .optional(),
   default: z.any().optional(),
 });
 


### PR DESCRIPTION
Upon using the get_flag_statuses_across_environments tool was failing on Zod validation when calling the flag status API. 

The issue: when requesting flag statuses across environments, the API returns null for lastRequested when a flag has never been evaluated, but our OpenAPI spec didn't mark this field as nullable.

We plan on fixing the OAS at the source, this change enables that tool to be used while we work that out. 

**FILES CHANGED** schemas/openapi.json

**Describe the solution you've provided**
Feature flag status:

* Updated the `FeatureFlagStatus` type and related schemas to allow `lastRequested` to be `null`, improving flexibility when this timestamp is absent. [[1]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL33-R33) [[2]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL67-R76) [[3]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL87-R88)
* Marked `lastRequested` as nullable in the API schemas (`schemas/openapi.json` and `schemas/output.json`), ensuring the OpenAPI documentation accurately reflects possible values. [[1]](diffhunk://#diff-46a811ad636c32360f66ff8bbb9e2e3981f25f183307ebc564988c1cae8ff2b6R37547) [[2]](diffhunk://#diff-46a811ad636c32360f66ff8bbb9e2e3981f25f183307ebc564988c1cae8ff2b6R38516) [[3]](diffhunk://#diff-a3956ba3b6c499ed7c238a4c678c7368a893abf7671a09b73d8ad29ca8296e91R38481) [[4]](diffhunk://#diff-a3956ba3b6c499ed7c238a4c678c7368a893abf7671a09b73d8ad29ca8296e91R39450)

**Describe alternatives you've considered**

Ideally, we make it so that the OAS at the source is accurate so that clients generating types from the schema dont encounter these issues, but that requires some more work in Gonfalon that will take a bit. 
See https://github.com/launchdarkly/gonfalon/pull/54762 for details

before: 
<img width="590" height="164" alt="Screenshot 2025-10-28 at 1 13 25 PM" src="https://github.com/user-attachments/assets/6445e593-5c38-4612-87a2-b79fd005836c" />

after:
<img width="270" height="343" alt="Screenshot 2025-10-28 at 1 14 47 PM" src="https://github.com/user-attachments/assets/a9beaa5b-223f-4018-a752-2c52d8914316" />
<!-- ld-jira-link -->
---
Related Jira issue: [REL-10407: Fix API drift when fetching flag status across environments](https://launchdarkly.atlassian.net/browse/REL-10407)
<!-- end-ld-jira-link -->