### PR TITLE
fix: restore environment variable fallback for API key

### DIFF
--- a/src/mcp-server/cli/start/impl.ts
+++ b/src/mcp-server/cli/start/impl.ts
@@ -50,7 +50,7 @@ async function startStdio(flags: StartCommandFlags) {
     logger,
     allowedTools: flags.tool,
     scopes: flags.scope,
-    ...{ apiKey: flags["api-key"] ?? "" },
+    ...{ apiKey: flags["api-key"] ?? undefined },
     serverURL: flags["server-url"],
     serverIdx: flags["server-index"],
   });
@@ -71,7 +71,7 @@ async function startSSE(flags: StartCommandFlags) {
     logger,
     allowedTools: flags.tool,
     scopes: flags.scope,
-    ...{ apiKey: flags["api-key"] ?? "" },
+    ...{ apiKey: flags["api-key"] ?? undefined },
     serverURL: flags["server-url"],
     serverIdx: flags["server-index"],
   });


### PR DESCRIPTION
### Description
This PR resolves an issue where the `LAUNCHDARKLY_API_KEY` environment variable fallback was ignored when the `--api-key` CLI flag was not provided.

### Problem
The root cause was that the CLI implementation defaulted the `apiKey` to an empty string (`""`) when the flag was missing. Because the security module uses the nullish coalescing operator (`??`) to handle fallbacks, the empty string was treated as a defined value, preventing the intended fallback to the environment variable.

### Solution
The default value for `apiKey` in the CLI start implementation has been changed from `""` to `undefined`. This allows the nullish coalescing logic to correctly fall back to the `LAUNCHDARKLY_API_KEY` environment variable when the CLI flag is omitted.

### Verification
Logic was verified by demonstrating that `undefined` allows the `??` operator to proceed to the fallback value, whereas `""` does not. 

This change improves support for MCP clients and automated environments that rely on environment variables for configuration.

#42 