### PR TITLE
fix(REL-12531): adding overlay for spec fixes for oas. bumping bug fix version

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,19 +1,19 @@
 lockVersion: 2.0.0
 id: cc3a5766-8b39-40da-a0be-fff57173d8e1
 management:
-  docChecksum: 3bf333ffd4b2b0d832c5511a7e7ff173
+  docChecksum: da671477b0465a22ab76ceea8dedb37e
   docVersion: "2.0"
   speakeasyVersion: 1.736.1
   generationVersion: 2.845.15
-  releaseVersion: 0.6.0
-  configChecksum: 976f9a3eab53c25137a5e27a963dcf9f
+  releaseVersion: 0.6.1
+  configChecksum: 2b1a4e81d4d79baeeaa073f49508a590
   repoURL: https://github.com/launchdarkly/mcp-server.git
   installationURL: https://github.com/launchdarkly/mcp-server
   published: true
 persistentEdits:
-  generation_id: c9f94ed6-fdb5-4186-8833-40022a1d0597
-  pristine_commit_hash: ef7273def0d4f9ecedf7c4cd0d65c94dfc01b038
-  pristine_tree_hash: f3ff54d7e32f317060981863152d5cc14567e21a
+  generation_id: 45b818b9-7b28-42cd-a52d-ab46291f5b68
+  pristine_commit_hash: 105bfe851067311d4aa37059bc5082fa0a742a14
+  pristine_tree_hash: 9e0dbd29eba3cfea130c7ec70072d64a679f8e9a
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -32,6 +32,7 @@ features:
     ignores: 2.81.1
     mcpServer: 0.9.4
     nameOverrides: 2.81.4
+    nullables: 0.1.1
     responseFormat: 0.3.0
     retries: 2.83.0
     sdkHooks: 0.4.0
@@ -735,12 +736,12 @@ trackedFiles:
     pristine_git_object: b6d40ae05716a1243a0adf677aef02a56b724541
   jsr.json:
     id: 7f6ab7767282
-    last_write_checksum: sha1:89ed0ca9be634c5a6cdde5a6a0f3132438d58bc7
-    pristine_git_object: 26ca5f132869d2bd2f01bc4464fc7bad5bc46943
+    last_write_checksum: sha1:60bcfa39114c45ed0d9f6cfaffca0bcf28176e4c
+    pristine_git_object: 2bbfb1cad7c598438f86edbf512d39834e500751
   package.json:
     id: 7030d0b2f71b
-    last_write_checksum: sha1:f429edd953308ae302061d209cd8545d8aec3a30
-    pristine_git_object: e4b50d14b5003c0ea3db3ab4436beec55893fd90
+    last_write_checksum: sha1:5547292855f64b8e58da9cf92f9f347e4e88e195
+    pristine_git_object: 3c1c18fd273d7cae91ac8fe43bfe0346d317f000
   src/core.ts:
     id: f431fdbcd144
     last_write_checksum: sha1:c5377e0f566bb6fa8c1f40abad8ed8e2afeff228
@@ -843,8 +844,8 @@ trackedFiles:
     pristine_git_object: 0aebd8b0a4867e35cb3348fc52921c3c0b4725b7
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:8060f84ef1eb510133a65b800a8416c65a6756cf
-    pristine_git_object: 51bf16a74bbc1e7e0663e3f6772d8995f7436a91
+    last_write_checksum: sha1:e2872cb8000c5227cc0547ae2c29ce88c27c6982
+    pristine_git_object: adfb0e6a6575e9b99304d1a157fd747760d02a6a
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:1dd3e3fbb4550c4bf31f5ef997faff355d6f3250
@@ -927,8 +928,8 @@ trackedFiles:
     pristine_git_object: 0955a573c2ce989d63c737410ab8cc28706d9f74
   src/mcp-server/mcp-server.ts:
     id: aabbc4ab07c1
-    last_write_checksum: sha1:14abc2979c582424ede0f99e2472bdf108dda818
-    pristine_git_object: 9b19ebc6ff00562e476a3ff8026ce96010803368
+    last_write_checksum: sha1:3d3374e7a9af9bdf8d737a7eb7726e03d20ea575
+    pristine_git_object: 78af261e961c59a4b6807fe8d5f7a1e3527c39ba
   src/mcp-server/prompts.ts:
     id: 26f3d73cbf31
     last_write_checksum: sha1:d6c2743fa03a583234144acfc5c3a5008a355107
@@ -943,8 +944,8 @@ trackedFiles:
     pristine_git_object: cb8330e4ae705d283de6ab337eefd3b4b8191fca
   src/mcp-server/server.ts:
     id: 2784dd48e82a
-    last_write_checksum: sha1:48742774d3b4f7b0c129f8b0425302bd0930245a
-    pristine_git_object: ae6587e12709fcc6ff1078a9ead7a8178ca0be04
+    last_write_checksum: sha1:9f44340ab6e80f81ccaf18ae1549d2446a4baae0
+    pristine_git_object: 34dfe1b36513bc490c3775378bd154c0b1e8f90c
   src/mcp-server/shared.ts:
     id: 074e80d4be1e
     last_write_checksum: sha1:56c73d4429691516e35541825e759a0285747a2b
@@ -1283,8 +1284,8 @@ trackedFiles:
     pristine_git_object: 4e9481ad6103095ac1cf896013605ff0f357d17b
   src/models/components/featureflagstatus.ts:
     id: f82c62603dcc
-    last_write_checksum: sha1:45df5a793f0920085f2c21b24d1d3cd3caea69e5
-    pristine_git_object: a4264ee044ac894ea492897c538c6734a065bd83
+    last_write_checksum: sha1:107893ce6575423077e3690e7050dc63b07128a9
+    pristine_git_object: 5611cb07af8f279bcdf27d6151dfd79517e215e6
   src/models/components/featureflagstatusacrossenvironments.ts:
     id: f2eaa2755cf8
     last_write_checksum: sha1:d6e51198f9fc877e4d808f6fd39513e8d540e2fe

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.6.0
+  version: 0.6.1
   acceptHeaderEnum: true
   additionalDependencies:
     dependencies:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.736.1
 sources:
     LaunchDarkly REST API:
         sourceNamespace: launchdarkly-rest-api
-        sourceRevisionDigest: sha256:660091d01912e6441740c604153fd0de5dca3b7098818b06bdf27f928b20b4a1
-        sourceBlobDigest: sha256:320f0be8ba411906a7ef897a0ae7c0e86119d186cb70850c014c6552e5c08f39
+        sourceRevisionDigest: sha256:128c9ec8c3aebbfed6add712e78fef0bc2570e04e60d65200a7f0ff107fac27d
+        sourceBlobDigest: sha256:5e904711ebc11f383579ff58b5c2c5f0d5c341c3d92c48bb1d93b4f5f4b1e5c6
         tags:
             - latest
             - "2.0"
@@ -11,10 +11,10 @@ targets:
     launchdarkly-mcp-server:
         source: LaunchDarkly REST API
         sourceNamespace: launchdarkly-rest-api
-        sourceRevisionDigest: sha256:660091d01912e6441740c604153fd0de5dca3b7098818b06bdf27f928b20b4a1
-        sourceBlobDigest: sha256:320f0be8ba411906a7ef897a0ae7c0e86119d186cb70850c014c6552e5c08f39
+        sourceRevisionDigest: sha256:128c9ec8c3aebbfed6add712e78fef0bc2570e04e60d65200a7f0ff107fac27d
+        sourceBlobDigest: sha256:5e904711ebc11f383579ff58b5c2c5f0d5c341c3d92c48bb1d93b4f5f4b1e5c6
         codeSamplesNamespace: launchdarkly-rest-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:462d803ace535f1c269b2831ba1f3baf7fdac6fe7289fd8cacb33ee0d57fd3a5
+        codeSamplesRevisionDigest: sha256:c2540075e36bdfdb4e66c7d37c308acd737c0808f87ca56bd0cd6ab36e7aee02
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.736.1
@@ -25,6 +25,7 @@ workflow:
             overlays:
                 - location: ./schemas/mcp-enable-tools.yaml
                 - location: ./schemas/suggestions.yaml
+                - location: ./schemas/spec-fixes.yaml
             output: ./schemas/output.json
             registry:
                 location: registry.speakeasyapi.dev/launchdarkly/mcp/launchdarkly-rest-api

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -7,6 +7,7 @@ sources:
         overlays:
             - location: ./schemas/mcp-enable-tools.yaml
             - location: ./schemas/suggestions.yaml
+            - location: ./schemas/spec-fixes.yaml
         output: ./schemas/output.json
         registry:
             location: registry.speakeasyapi.dev/launchdarkly/mcp/launchdarkly-rest-api

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@launchdarkly/mcp-server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@launchdarkly/mcp-server",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchdarkly/mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "LaunchDarkly",
   "keywords": [
     "feature-flags",

--- a/schemas/output.json
+++ b/schemas/output.json
@@ -42847,7 +42847,8 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp of last time flag was requested",
-            "example": "2020-02-05T18:17:01.514Z"
+            "example": "2020-02-05T18:17:01.514Z",
+            "nullable": true
           },
           "default": {
             "description": "Default value seen from code"
@@ -43815,7 +43816,8 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp of last time flag was requested",
-            "example": "2020-02-05T18:17:01.514Z"
+            "example": "2020-02-05T18:17:01.514Z",
+            "nullable": true
           },
           "default": {
             "description": "Default value seen from code"

--- a/schemas/spec-fixes.yaml
+++ b/schemas/spec-fixes.yaml
@@ -1,0 +1,13 @@
+overlay: 1.0.0
+info:
+  title: Spec Fixes Overlay
+  version: 0.0.1
+actions:
+  - target: $["components"]["schemas"]["FeatureFlagStatus"]["properties"]["lastRequested"]
+    description: "API returns null for lastRequested when a flag has never been evaluated"
+    update:
+      nullable: true
+  - target: $["components"]["schemas"]["FlagStatusRep"]["properties"]["lastRequested"]
+    description: "API returns null for lastRequested when a flag has never been evaluated"
+    update:
+      nullable: true

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,8 +69,8 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "2.0",
-  sdkVersion: "0.6.0",
+  sdkVersion: "0.6.1",
   genVersion: "2.845.15",
   userAgent:
-    "speakeasy-sdk/typescript 0.6.0 2.845.15 2.0 @launchdarkly/mcp-server",
+    "speakeasy-sdk/typescript 0.6.1 2.845.15 2.0 @launchdarkly/mcp-server",
 } as const;

--- a/src/mcp-server/mcp-server.ts
+++ b/src/mcp-server/mcp-server.ts
@@ -19,7 +19,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
   name: "mcp",
   versionInfo: {
-    currentVersion: "0.6.0",
+    currentVersion: "0.6.1",
   },
 });
 

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -43,7 +43,7 @@ export function createMCPServer(deps: {
 }) {
   const server = new McpServer({
     name: "LaunchDarkly",
-    version: "0.6.0",
+    version: "0.6.1",
   });
 
   const client = new LaunchDarklyCore({

--- a/src/models/components/featureflagstatus.ts
+++ b/src/models/components/featureflagstatus.ts
@@ -30,7 +30,7 @@ export type FeatureFlagStatus = {
   /**
    * Timestamp of last time flag was requested
    */
-  lastRequested?: Date | undefined;
+  lastRequested?: Date | null | undefined;
   /**
    * Default value seen from code
    */
@@ -52,15 +52,15 @@ export const FeatureFlagStatus$inboundSchema: z.ZodType<
   unknown
 > = z.object({
   name: Name$inboundSchema,
-  lastRequested: z.string().datetime({ offset: true }).transform(v =>
-    new Date(v)
+  lastRequested: z.nullable(
+    z.string().datetime({ offset: true }).transform(v => new Date(v)),
   ).optional(),
   default: z.any().optional(),
 });
 /** @internal */
 export type FeatureFlagStatus$Outbound = {
   name: string;
-  lastRequested?: string | undefined;
+  lastRequested?: string | null | undefined;
   default?: any | undefined;
 };
 
@@ -71,7 +71,8 @@ export const FeatureFlagStatus$outboundSchema: z.ZodType<
   FeatureFlagStatus
 > = z.object({
   name: Name$outboundSchema,
-  lastRequested: z.date().transform(v => v.toISOString()).optional(),
+  lastRequested: z.nullable(z.date().transform(v => v.toISOString()))
+    .optional(),
   default: z.any().optional(),
 });
 


### PR DESCRIPTION
This pull request updates the MCP server to version 0.6.1 and introduces schema and code changes to allow the `lastRequested` property for feature flags to be nullable. This ensures the API correctly represents cases where a flag has never been evaluated. The changes are mainly focused on version updates, schema overlays, and TypeScript model adjustments.

Version updates:

* Updated the MCP server version from `0.6.0` to `0.6.1` across multiple files including `package.json`, `jsr.json`, `examples/package-lock.json`, `.speakeasy/gen.yaml`, `src/lib/config.ts`, `src/mcp-server/mcp-server.ts`, and `src/mcp-server/server.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-5193a148ebdd2baf23b4f0a1c1add7ea02a8b92fb022e3a5780e886509d06693L5-R5) [[3]](diffhunk://#diff-4eba0ce958c8cf0181ffae8755bd7c08041f0259add922df5d173153a4278a1eL21-R21) [[4]](diffhunk://#diff-0f2bcc849ddce1a74ff8c03418150e851b1fb947992e6b14f76346a205806559L35-R35) [[5]](diffhunk://#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ffL72-R75) [[6]](diffhunk://#diff-87a16a618292bd5d800adafbb50a52b346c7707fd51ad80843a5e1ac550a7295L22-R22) [[7]](diffhunk://#diff-a621a380faf133923060ab725f4cf447b62db8282aae6edcabe8542ee504c6c4L46-R46)

Schema and overlay changes:

* Added a new overlay file `schemas/spec-fixes.yaml` and included it in the build workflow to mark `lastRequested` as nullable for both `FeatureFlagStatus` and `FlagStatusRep` schemas. [[1]](diffhunk://#diff-d51f296cea96f42ce1ee07d5bc698adb6989bae3fd678ac6c429eaf1767616e4R1-R13) [[2]](diffhunk://#diff-07a627252d51850cb5031c8550183e6cf8dd9535eef9ac6a29f28d6c55a4f01dR10)
* Updated `schemas/output.json` to set the `nullable` property to true for `lastRequested` in relevant schemas. [[1]](diffhunk://#diff-a3956ba3b6c499ed7c238a4c678c7368a893abf7671a09b73d8ad29ca8296e91L42850-R42851) [[2]](diffhunk://#diff-a3956ba3b6c499ed7c238a4c678c7368a893abf7671a09b73d8ad29ca8296e91L43818-R43820)

TypeScript model adjustments:

* Modified the `FeatureFlagStatus` TypeScript model and Zod schemas to support `lastRequested` as `Date | null | undefined` and updated inbound/outbound schema handling accordingly. [[1]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL33-R33) [[2]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL55-R63) [[3]](diffhunk://#diff-aac4fc4f81b67b3871760707788e9dbfcae63c560cfca788343fe3456c6dc28eL74-R75)
<!-- ld-jira-link -->
---
Related Jira issue: [REL-12531: Versions 0.6.0 and 0.5.0 of MCP server error when getStatus (get flag status across environments) is called](https://launchdarkly.atlassian.net/browse/REL-12531)
<!-- end-ld-jira-link -->