### PR TITLE
docs(mcp): clarify feature flag discovery vs canonical UI navigation

### DIFF
--- a/src/mcp-server/tools/featureFlagsGet.ts
+++ b/src/mcp-server/tools/featureFlagsGet.ts
@@ -13,7 +13,7 @@ const args = {
 export const tool$featureFlagsGet: ToolDefinition<typeof args> = {
   name: "get-feature-flag",
   description:
-    `Fetches the full configuration for a specific feature flag, including environments, variations, and targeting rules. For navigation/open-in-browser flows, use environments.<environmentKey>._site.href from this response as the canonical UI path for that environment.
+    `Fetches the full configuration for a specific feature flag, including environments, variations, and targeting rules. For navigation/open-in-browser flows, use environments.<environmentKey>.site.href from this response as the canonical UI path for that environment.
 `,
   scopes: ["read"],
   args,

--- a/src/mcp-server/tools/featureFlagsGet.ts
+++ b/src/mcp-server/tools/featureFlagsGet.ts
@@ -13,7 +13,7 @@ const args = {
 export const tool$featureFlagsGet: ToolDefinition<typeof args> = {
   name: "get-feature-flag",
   description:
-    `Fetches the full configuration for a specific feature flag, including environments, variations, and targeting rules. Useful for agents auditing or managing specific feature toggles in a detailed, contextual manner.
+    `Fetches the full configuration for a specific feature flag, including environments, variations, and targeting rules. For navigation/open-in-browser flows, use environments.<environmentKey>._site.href from this response as the canonical UI path for that environment.
 `,
   scopes: ["read"],
   args,

--- a/src/mcp-server/tools/featureFlagsList.ts
+++ b/src/mcp-server/tools/featureFlagsList.ts
@@ -13,7 +13,7 @@ const args = {
 export const tool$featureFlagsList: ToolDefinition<typeof args> = {
   name: "list-feature-flags",
   description:
-    `Retrieves all feature flags within a project, including metadata and targeting rules. Enables AI agents to enumerate existing flags for inspection, configuration analysis, or generating flag usage reports across environments. IMPORTANT: Do not fabricate UI URLs from project/key. This endpoint is for discovery; when a user asks to open a flag, call get-feature-flag and use environments.<environmentKey>._site.href from that response. The 'filter' parameter uses field:value syntax — to search by keyword use query:<search-text> (e.g. filter: "query:dark-mode"). Other supported filters: tags:<tag>, state:live|deprecated|archived, hasExperiment:true|false, maintainerId:<id>, hasDataExport:true|false. Combine with commas.
+    `Retrieves all feature flags within a project, including metadata and targeting rules. Enables AI agents to enumerate existing flags for inspection, configuration analysis, or generating flag usage reports across environments. IMPORTANT: Do not fabricate UI URLs from project/key. This endpoint is for discovery; when a user asks to open a flag, call get-feature-flag and use environments.<environmentKey>.site.href from that response. The 'filter' parameter uses field:value syntax — to search by keyword use query:<search-text> (e.g. filter: "query:dark-mode"). Other supported filters: tags:<tag>, state:live|deprecated|archived, hasExperiment:true|false, maintainerId:<id>, hasDataExport:true|false. Combine with commas.
 `,
   scopes: ["read"],
   args,

--- a/src/mcp-server/tools/featureFlagsList.ts
+++ b/src/mcp-server/tools/featureFlagsList.ts
@@ -13,7 +13,7 @@ const args = {
 export const tool$featureFlagsList: ToolDefinition<typeof args> = {
   name: "list-feature-flags",
   description:
-    `Retrieves all feature flags within a project, including metadata and targeting rules. Enables AI agents to enumerate existing flags for inspection, configuration analysis, or generating flag usage reports across environments.
+    `Retrieves all feature flags within a project, including metadata and targeting rules. Enables AI agents to enumerate existing flags for inspection, configuration analysis, or generating flag usage reports across environments. IMPORTANT: Do not fabricate UI URLs from project/key. This endpoint is for discovery; when a user asks to open a flag, call get-feature-flag and use environments.<environmentKey>._site.href from that response. The 'filter' parameter uses field:value syntax — to search by keyword use query:<search-text> (e.g. filter: "query:dark-mode"). Other supported filters: tags:<tag>, state:live|deprecated|archived, hasExperiment:true|false, maintainerId:<id>, hasDataExport:true|false. Combine with commas.
 `,
   scopes: ["read"],
   args,


### PR DESCRIPTION
## Summary
- Clarifies that `list-feature-flags` is for discovery and should not be used to construct UI links.
- Documents the canonical navigation flow: call `get-feature-flag` and use `environments.<environmentKey>.site.href`.
- Adds explicit `filter` guidance (`query:<text>`, `tags`, `state`, `hasExperiment`, `maintainerId`, `hasDataExport`) to improve agent query quality.

<img width="832" height="191" alt="image" src="https://github.com/user-attachments/assets/6adb8451-17d0-4157-aadd-4c4fbf74d414" />



## Test plan
- [x] Reviewed tool descriptions for correctness and consistency.
- [x] Confirmed no runtime/tool registration behavior changes.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/mcp-server/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
