### PR TITLE
fix(mcp): normalize LaunchDarkly hrefs to API response origin in tool output

### DIFF
--- a/src/mcp-server/tools.ts
+++ b/src/mcp-server/tools.ts
@@ -51,13 +51,15 @@ export async function formatResult(
   const contentType = response?.headers.get("content-type") ?? "";
   let content: CallToolResult["content"] = [];
 
-  if (contentType.search(/\bjson\b/g)) {
-    content = [{ type: "text", text: JSON.stringify(value) }];
+  const normalizedValue = normalizeLaunchDarklyLinks(value, response?.url);
+
+  if (/\bjson\b/g.test(contentType)) {
+    content = [{ type: "text", text: JSON.stringify(normalizedValue) }];
   } else if (
     contentType.startsWith("text/event-stream")
-    && isAsyncIterable(value)
+    && isAsyncIterable(normalizedValue)
   ) {
-    content = await consumeSSE(value);
+    content = await consumeSSE(normalizedValue);
   } else if (contentType.startsWith("text/") && typeof value === "string") {
     content = [{ type: "text", text: value }];
   } else if (isBinaryData(value) && contentType.startsWith("image/")) {
@@ -76,6 +78,78 @@ export async function formatResult(
   }
 
   return { content };
+}
+
+const canonicalLDHosts = new Set([
+  "app.launchdarkly.com",
+  "app.launchdarkly.us",
+]);
+
+function normalizeLaunchDarklyLinks(
+  value: unknown,
+  responseURL?: string,
+): unknown {
+  if (!responseURL) {
+    return value;
+  }
+
+  let origin: string;
+  try {
+    origin = new URL(responseURL).origin;
+  } catch {
+    return value;
+  }
+
+  return deepMap(value, (key, val) => {
+    if (key !== "href" || typeof val !== "string") {
+      return val;
+    }
+
+    if (val.startsWith("/")) {
+      try {
+        return new URL(val, origin).toString();
+      } catch {
+        return val;
+      }
+    }
+
+    try {
+      const parsed = new URL(val);
+      if (canonicalLDHosts.has(parsed.host) && parsed.origin !== origin) {
+        return `${origin}${parsed.pathname}${parsed.search}${parsed.hash}`;
+      }
+    } catch {
+      // Leave invalid URL-ish strings unchanged.
+    }
+
+    return val;
+  });
+}
+
+function deepMap(
+  value: unknown,
+  transform: (key: string | null, value: unknown) => unknown,
+  key: string | null = null,
+): unknown {
+  const transformed = transform(key, value);
+
+  if (Array.isArray(transformed)) {
+    return transformed.map((item) => deepMap(item, transform));
+  }
+
+  if (
+    transformed !== null
+    && typeof transformed === "object"
+    && Object.getPrototypeOf(transformed) === Object.prototype
+  ) {
+    const output: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(transformed as Record<string, unknown>)) {
+      output[k] = deepMap(v, transform, k);
+    }
+    return output;
+  }
+
+  return transformed;
 }
 
 async function consumeSSE(

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { formatResult } from "../src/mcp-server/tools.js";
+
+describe("formatResult link normalization", () => {
+  test("rewrites app.launchdarkly.com href to response origin", async () => {
+    const origin = "https://random-domain.example.test";
+    const input = {
+      _links: {
+        site: {
+          href: "https://app.launchdarkly.com/default/production/features/flag-a",
+        },
+      },
+    };
+
+    const response = {
+      headers: new Headers({ "content-type": "application/json" }),
+      url: `${origin}/api/v2/flags/default/flag-a`,
+    };
+
+    const result = await formatResult(input, { response });
+    const text = result.content[0];
+    expect(text?.type).toBe("text");
+    const parsed = JSON.parse(text.text);
+    expect(parsed._links.site.href).toBe(
+      `${origin}/default/production/features/flag-a`,
+    );
+  });
+
+  test("rewrites app.launchdarkly.us href to response origin", async () => {
+    const origin = "https://federal-alt.example.test";
+    const input = {
+      _links: {
+        site: {
+          href: "https://app.launchdarkly.us/default/production/features/flag-c",
+        },
+      },
+    };
+
+    const response = {
+      headers: new Headers({ "content-type": "application/json" }),
+      url: `${origin}/api/v2/flags/default/flag-c`,
+    };
+
+    const result = await formatResult(input, { response });
+    const text = result.content[0];
+    expect(text?.type).toBe("text");
+    const parsed = JSON.parse(text.text);
+    expect(parsed._links.site.href).toBe(
+      `${origin}/default/production/features/flag-c`,
+    );
+  });
+
+  test("expands relative href against response origin", async () => {
+    const origin = "https://another-random.example.test";
+    const input = {
+      _links: {
+        site: {
+          href: "/default/production/features/flag-b",
+        },
+      },
+    };
+
+    const response = {
+      headers: new Headers({ "content-type": "application/json" }),
+      url: `${origin}/api/v2/flags/default/flag-b`,
+    };
+
+    const result = await formatResult(input, { response });
+    const text = result.content[0];
+    expect(text?.type).toBe("text");
+    const parsed = JSON.parse(text.text);
+    expect(parsed._links.site.href).toBe(
+      `${origin}/default/production/features/flag-b`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Updates `formatResult` to normalize `href` links using the actual response origin, including relative and canonical LaunchDarkly host URLs.
- Prevents mismatched `.com`/`.us` links from leaking into tool output when requests are served from alternate domains.
- Adds focused tests for `.com`, `.us`, and relative-path link normalization behavior.
- Includes a small JSON content-type check fix so normalization is consistently applied to JSON responses.

### Context
> "Take me there" - should open up the proper domain relative to MCP configuration - currently always uses `.com`

## Test plan
- [x] `bun test tests/tools.test.js`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/mcp-server/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
