### PR TITLE
feat: add audit log entries tool

### DIFF
--- a/schemas/mcp-enable-tools.yaml
+++ b/schemas/mcp-enable-tools.yaml
@@ -86,6 +86,19 @@ actions:
         name: get-environments
         scopes:
           - read
+  - target: $["paths"]["/api/v2/auditlog"]["get"]
+    update:
+      x-speakeasy-mcp:
+        description: >
+          Fetches audit log entries for a LaunchDarkly account. Use the `spec` parameter
+          with format `proj/<projectKey>:env/<envKey>:flag/<flagKey>` to query a specific
+          flag's change history (use `env/*` for all environments). The `before` and `after`
+          parameters accept Unix epoch timestamps in milliseconds for date-range filtering.
+          Returns at most 20 entries per call, ordered newest-first.
+        disabled: false
+        name: get-audit-log-entries
+        scopes:
+          - read
   - target: $["paths"]["/api/v2/code-refs/repositories"]["get"]
     update:
       x-speakeasy-mcp:


### PR DESCRIPTION
## Related issues

This addresses a gap in the current MCP tool surface — the audit log API is already in the OpenAPI spec and has Speakeasy naming hints in `schemas/suggestions.yaml`, but is not exposed as an MCP tool.

## Describe the solution you've provided

Adds a single entry to `schemas/mcp-enable-tools.yaml` to enable the `GET /api/v2/auditlog` endpoint as a read-only MCP tool (`get-audit-log-entries`).

The tool description includes practical guidance for AI agents:
- Resource specifier syntax for querying flag change history (`proj/<projectKey>:env/<envKey>:flag/<flagKey>`)
- Pagination pattern using `before`/`after` Unix epoch timestamps
- Response limit behavior (max 20 entries per call, newest-first)

**Note:** This PR only contains the overlay change. Since the codebase is generated by Speakeasy and external contributors cannot run `speakeasy run` against the LaunchDarkly registry, the generated output (funcs, tools, models, server registration) will need to be produced by the maintainers.

## Describe alternatives you've considered

### Context window optimization

Adding more tools increases the MCP context window footprint for all users, even those who don't need audit log access. The existing `--tool` flag allows whitelisting specific tools, but there's no easy way to _exclude_ a single tool without listing all the others.

A few ideas worth considering (as a separate effort):

1. **`--exclude-tool` flag** — inverse of `--tool`, letting users opt out of specific tools without listing everything else.
2. **Tool groups** (e.g. `--tool-group flags`, `--tool-group audit-log`, `--tool-group ai-configs`) — would let users selectively load categories of tools. This would be especially valuable since AI Configs alone accounts for 11 of the 20 current tools.
3. **Documenting `--tool` and `--scope`** — these existing flags aren't mentioned in the README. Simply documenting them would help users who want to reduce context window usage today.

## Additional context

- The audit log endpoint is already present in `schemas/openapi.json` with operationId `getAuditLogEntries`
- `schemas/suggestions.yaml` already defines `x-speakeasy-group: auditLog` and `x-speakeasy-name-override: listEntries` for this endpoint
- The tool is scoped as `read`-only