### PR TITLE
docs: recommend hosted MCP server and clarify local server scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LaunchDarkly local MCP server
 
-The official local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [LaunchDarkly](https://launchdarkly.com/).
+The local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [LaunchDarkly](https://launchdarkly.com/) federal and European Union (EU) environments.
 
 <div align="left">
     <a href="https://opensource.org/licenses/MIT">
@@ -9,11 +9,11 @@ The official local [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 </div>
 
 > [!IMPORTANT]
-> **Most customers should use LaunchDarkly's [hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp-hosted) instead of this one.**
+> **Use the LaunchDarkly [hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp-hosted) where available**
 >
-> LaunchDarkly [strongly recommends the hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp): it is more feature complete and receives more frequent updates than this self-managed server.
+> LaunchDarkly strongly recommends using the [hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp) where it is available. The hosted server is more feature complete and receives more frequent updates than this self-managed server.
 >
-> Use this self-managed MCP server only if you are on LaunchDarkly's **EU** or **Federal** instances, which are not yet supported by the hosted MCP server.
+> LaunchDarkly provides this self-managed MCP server for LaunchDarkly **EU** or **Federal** instances, which do not yet support the hosted MCP.
 
 <!-- No Summary [summary] -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LaunchDarkly's Model Context Protocol (MCP) Server
+# LaunchDarkly local MCP server
 
-The official [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [LaunchDarkly](https://launchdarkly.com/).
+The official local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for [LaunchDarkly](https://launchdarkly.com/).
 
 <div align="left">
     <a href="https://opensource.org/licenses/MIT">
@@ -8,12 +8,19 @@ The official [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) se
     </a>
 </div>
 
+> [!IMPORTANT]
+> **Most customers should use LaunchDarkly's [hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp-hosted) instead of this one.**
+>
+> LaunchDarkly [strongly recommends the hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp): it is more feature complete and receives more frequent updates than this self-managed server.
+>
+> Use this self-managed MCP server only if you are on LaunchDarkly's **EU** or **Federal** instances, which are not yet supported by the hosted MCP server.
+
 <!-- No Summary [summary] -->
 
 <!-- Start Table of Contents [toc] -->
 ## Table of Contents
 <!-- $toc-max-depth=2 -->
-* [LaunchDarkly's Model Context Protocol (MCP) Server](#launchdarklys-model-context-protocol-mcp-server)
+* [LaunchDarkly local MCP server](#launchdarkly-local-mcp-server)
   * [Installation](#installation)
   * [Requirements](#requirements)
   * [Available Resources and Operations](#available-resources-and-operations)


### PR DESCRIPTION
## Summary

Updates the README to steer customers toward LaunchDarkly's hosted MCP server, which is the better fit for most customers.

- Adds an `[!IMPORTANT]` callout near the top recommending the [hosted MCP server](https://launchdarkly.com/docs/home/getting-started/mcp-hosted), which is more feature complete and updated more frequently.
- Clarifies that this self-managed/local server should be used only by customers on LaunchDarkly's **EU** or **Federal** instances, which the hosted MCP server does not yet support.
- Retitles the README to **"LaunchDarkly local MCP server"** and updates the description line to "The official local ... server", with the Table of Contents anchor updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)